### PR TITLE
Fix: GameManager 모든 메서드 상세 구현, CheckTanghuluAndScore 메서드 삭제

### DIFF
--- a/Assets/_Script/GameManager.cs
+++ b/Assets/_Script/GameManager.cs
@@ -1,16 +1,31 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq.Expressions;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+
+public enum GameState
+{
+    MainMenu,
+    Playing,
+    Paused,
+    GameOver,
+}
 
 public class GameManager : MonoBehaviour
 {
     public static GameManager Instance { get; private set; }
 
+    public GameState currentState;
+
     public int currentPhase = 1;
     public int tanghuluMade = 0;
-    public int highScore = 0; // 얘는, PlayerPrefs 또는 json으로 저장한거에서 불러오는 내용으로 초기화?
+    public int highScore = 0; // 얘는, PlayerPrefs 또는 json 등의 내용으로 초기화 할 듯
     public int score = 0;
+
+    private int minFruitType = 0;
+    private int maxFruitType = 2;
+    int[] targetTanghulu = new int[3];
 
     // 데이터나 기타 변수 작성
 
@@ -21,6 +36,10 @@ public class GameManager : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(gameObject);
+            InitializeGameState();
+
+            // PlayerPrefs를 사용하는 경우
+            highScore = PlayerPrefs.GetInt("HighScore", 0);
         }
         else
         {
@@ -28,12 +47,50 @@ public class GameManager : MonoBehaviour
         }
     }
 
-    // 게임 시작 메서드
+    private void InitializeGameState()
+    {
+        // 게임 상태를 MainMenu로 초기화
+        ChangeState(GameState.MainMenu);
+    }
+
+    public void ChangeState(GameState newState)
+    {
+        currentState = newState;
+
+        // 상태 변경에 따른 추가 로직 (예: UI 업데이트, 게임 데이터 초기화 등)
+        switch (currentState)
+        {
+            case GameState.MainMenu: // 메인 메뉴 로직
+                Time.timeScale = 1; // 게임 로직 일시 정지
+                // SoundManager.Instance.PlayMainMenuMusic(); // 메인메뉴 배경음악 재생
+                break;
+
+            case GameState.Playing: // 게임 시작 로직
+                Time.timeScale = 1; // 게임 로직 일시 정지
+                // SoundManager.Instance.PlayGameMusic(); // 현재 사운드가 게임중 사운드가 아니라면 게임중 사운드로 전환, (희망사항)배속 x1
+                break;
+
+            case GameState.Paused: // 일시 정지 관련 로직
+                Time.timeScale = 0; // 일시 정지 중 멈추기
+                // UIManager.Instance.ShowPauseMenu(); // 일시 정지 메뉴 활성화
+                // SoundManager.Instance.PauseMusic(); // (희망사항) 필요 시 배경음악 일시 정지 또는 볼륨 감소
+                break;
+
+            case GameState.GameOver: // 게임 종료 관련 로직
+                Time.timeScale = 0; // (필요 시 조율) 결과화면 중 멈추기
+                // UpdateHighScore(); // 최고 점수 업데이트 및 저장
+                // UIManager.Instance.ShowGameOverMenu(); // 게임 오버 UI 활성화
+                // SoundManager.Instance.PlayGameOverSound(); // 게임 오버 사운드 재생
+                break;
+        }
+    }
+
+    // 게임 시작 메서드 : 게임 시작 버튼이 눌렸을 때, ButtonManager에서 호출 바람.
     public void StartGame()
     {
         LoadMainScene();
+        ChangeState(GameState.Playing);
 
-        // 초기화 및 게임 시작에 필요한 로직
         StartDroppingFruits();
     }
 
@@ -43,58 +100,58 @@ public class GameManager : MonoBehaviour
         SceneManager.LoadScene("MainScene");
     }
 
-    // 과일 떨구기(로직 당장 생각이 안남.. 이후 구현 예정. 일단 메서드 명 참고)
+    // 과일 떨구기(로직 당장 생각이 안남.. 이후 구현 예정)
     public void StartDroppingFruits()
     {
-        // int currentPhase 에 따라 낙하하는 과일 설정
         // 과일이 떨어지기 시작하는 로직
+        // int currentPhase 에 따라 낙하하는 과일 종류 수에 반영
     }
 
     // 목표 탕후루 생성 및 표시
     public void GenerateTargetTanghulu()
     {
-        // int currentPhase 에 따라 목표 탕후루 설정
-        // 랜덤한 과일 3종류를 선택하여 목표 탕후루를 생성하고 표시하는 로직(화면에 표시하는 로직은 아마 별도 메서드에 작성하여 여기서 호출)
+        // 랜덤한 과일 {currentPhase + 2}종류를 선택하여 목표 탕후루를 생성하고 표시하는 로직
+        maxFruitType = currentPhase + 1;
+        for (int i = 0; i < targetTanghulu.Length; i++)
+        {
+            targetTanghulu[i] = Random.Range(minFruitType, maxFruitType + 1);
+        }
+
+        // 화면에 표시하는 로직은 별도 UI메서드에 작성하여 여기서 호출
+        // UIManager.Instance.ShowTargetTanghulu(targetTanghulu);
     }
 
-    // 목표 탕후루와 플레이어의 탕후루 검사 및 점수 반영
-    public void CheckTanghuluAndScore()
-    {
-        // 플레이어 탕후루와 목표 탕후루를 비교하고 점수를 반영하는 로직
-    }
-
-    // 탕후루 만들기 진행 상황 업데이트
-    public void UpdateTanghuluProgress()
+    // Player에서 과일 세개 쌓이면 int[3] 매개변수로 넣어 호출 바람. 점수반영, 난이도 관리, 종료 조건 검사 수행
+    public void UpdateTanghuluProgress(int[] playerTanghulu)
     {
         tanghuluMade++;
+        CalculateAndUpdateScore(); // 플레이어 탕후루와 목표 탕후루를 비교하고 점수를 반영
         if (tanghuluMade % 4 == 0 || tanghuluMade % 7 == 0)
         {
             IncreaseDifficulty(); // 난이도 상승
         }
-
+        // 또한 종료 조건 만족 시 결과 관련 메서드
         if (tanghuluMade >= 10)
         {
-            ShowEndingUI(); // Ending UI 표시
+            ChangeState(GameState.GameOver);
         }
+    }
+    public void UpdateTanghuluProgress() // 입력 없을 경우, 0,0,0 전달
+    {
+        UpdateTanghuluProgress(new int[] { 0, 0, 0 });
     }
 
     // 난이도 상승
     public void IncreaseDifficulty()
     {
         currentPhase++;
-        // 난이도(Phase)를 상승시키는 로직
     }
 
     // 점수 계산 및 업데이트
     public void CalculateAndUpdateScore()
     {
         // 점수 계산 및 업데이트 로직
-    }
-
-    // Ending UI 표시
-    public void ShowEndingUI()
-    {
-        // 게임 종료 UI 표시 로직
+        score += 1; // 임시 작성
     }
 
     // ...추가 게임 관리 로직들 작성


### PR DESCRIPTION
[참고사항]
- 과일 세 개가 쌓이면, 과일의 정보를 넣은 UpdateTanghuluProgress() 호출 바람.
- 게임 시작 버튼이 눌렸을 때, ButtonManager에서 StartGame() 호출 바람.
- 일시정지 시, ChangeState(GameState.Paused) 호출
- 메인메뉴로 진입할 시, ChangeState(GameState.MainMenu) 호출

[구현 예정]
- 목표 탕후루의 화면에 표시
- 과일을 떨어뜨리기
- 점수계산
- 이외 부족한 점 계속 업데이트