### PR TITLE
Fix: StartGame 관련 이상 로직 해결, ButtonManager에 사용예시 작성, 씬 이름 오타 수정

### DIFF
--- a/Assets/_Script/ButtonManager.cs
+++ b/Assets/_Script/ButtonManager.cs
@@ -13,6 +13,26 @@ public class ButtonManager : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        
+
+    }
+    public void StartGame()
+    {
+        GameManager.Instance.StartGame();
+    }
+    public void PauseGame()
+    {
+        GameManager.Instance.PauseGame();
+    }
+    public void BackMainMenu()
+    {
+        GameManager.Instance.BackMainMenu();
+    }
+    public void ResumeGame()
+    {
+        GameManager.Instance.ResumeGame();
+    }
+    public void RestartGame()
+    {
+        GameManager.Instance.RestartGame();
     }
 }

--- a/Assets/_Script/GameManager.cs
+++ b/Assets/_Script/GameManager.cs
@@ -55,53 +55,84 @@ public class GameManager : MonoBehaviour
 
     public void ChangeState(GameState newState)
     {
-        GameState preState = currentState;
         currentState = newState;
 
-        // 상태 변경에 따른 추가 로직 (예: UI 업데이트, 게임 데이터 초기화 등)
+        // 상태 변경에 따른 추가 로직
         switch (currentState)
         {
             case GameState.MainMenu: // 메인 메뉴 로직
                 Time.timeScale = 1; // 타임스케일 정상화
-                ResetData();
                 // SoundManager.Instance.PlayMainMenuMusic(); // 메인메뉴 배경음악 재생
                 break;
 
             case GameState.Playing: // 게임 시작 로직
                 Time.timeScale = 1; // 타임스케일 정상화
-                if(preState != GameState.Paused) // 일시정지했다가 온 게 아니라면 데이터 리셋. 추후 나은 방안 마련
-                    ResetData();
                 // SoundManager.Instance.PlayGameMusic(); // 현재 사운드가 게임중 사운드가 아니라면 게임중 사운드로 전환, (희망사항)배속 x1
                 break;
 
             case GameState.Paused: // 일시 정지 관련 로직
                 Time.timeScale = 0; // 타임스케일 일시정지
-                UIManager.Instance.TogglePausedPanel(); // 일시 정지 메뉴 활성화
                 // SoundManager.Instance.PauseMusic(); // (희망사항) 필요 시 배경음악 일시 정지 또는 볼륨 감소
                 break;
 
             case GameState.GameOver: // 게임 종료 관련 로직
                 Time.timeScale = 0; // (필요 시 조율) 타임스케일 일시정지
-                UpdateHighScore(); // 최고 점수 업데이트 및 저장
-                UIManager.Instance.ToggleResultPanel(); // 게임 오버 UI 활성화
                 // SoundManager.Instance.PlayGameOverSound(); // 게임 오버 사운드 재생
                 break;
         }
     }
 
-    // 게임 시작 메서드 : 게임 시작 버튼이 눌렸을 때, ButtonManager에서 호출 바람.
+    // 게임시작 버튼이 눌렸을 때, ButtonManager에서 호출
     public void StartGame()
     {
+        ResetData();
         LoadMainScene();
-        ChangeState(GameState.Playing);
-
         StartDroppingFruits();
+        ChangeState(GameState.Playing);
+    }
+    // 일시정지 버튼이 눌렸을 때, ButtonManager에서 호출
+    public void PauseGame()
+    {
+        UIManager.Instance.TogglePausedPanel(); // 일시 정지 메뉴 토글
+        ChangeState(GameState.Paused);
+    }
+    // 이어하기 버튼이 눌렸을 때, ButtonManager에서 호출
+    public void ResumeGame()
+    {
+        UIManager.Instance.TogglePausedPanel(); // 일시 정지 메뉴 토글
+        ChangeState(GameState.Playing);
+    }
+    // 다시하기 버튼이 눌렸을 때, ButtonManager에서 호출
+    public void RestartGame()
+    {
+        ResetData();
+        LoadMainScene();
+        StartDroppingFruits();
+        ChangeState(GameState.Playing);
+    }
+    // 메인메뉴로 버튼이 눌렸을 때, ButtonManager에서 호출
+    public void BackMainMenu()
+    {
+        LoadTitleScene();
+        ChangeState(GameState.MainMenu);
+    }
+    // 게임 종료 조건 달성 시, GameManager에서 호출
+    public void GameOver()
+    {
+        UpdateHighScore(); // 최고 점수 업데이트 및 저장
+        UIManager.Instance.ToggleResultPanel(); // 게임 오버 UI 활성화
+        ChangeState(GameState.GameOver);
     }
 
     // MainScene 로드
     public void LoadMainScene()
     {
-        SceneManager.LoadScene("MainScene");
+        SceneManager.LoadScene("_MainScene");
+    }
+    // TitleScene 로드
+    public void LoadTitleScene()
+    {
+        SceneManager.LoadScene("_TitleScene");
     }
 
     // 게임 재시작을 위한 게임 데이터 초기화 메서드

--- a/Assets/_Script/UIManager.cs
+++ b/Assets/_Script/UIManager.cs
@@ -43,11 +43,11 @@ public class UIManager : MonoBehaviour
     private void FindAndAssignUIElements(Scene scene)
     {
         // 로드되는 씬 이름에 따라 UI를 로드
-        if (scene.name == "TitleScene")
+        if (scene.name == "_TitleScene")
         {
             settingsPanel = GameObject.Find("SettingUI");
         }
-        else if (scene.name == "MainScene")
+        else if (scene.name == "_MainScene")
         {
             pausedPanel = GameObject.Find("PauseUI");
             resultPanel = GameObject.Find("ScoreUI");


### PR DESCRIPTION
** Title 및 Main 씬에서 테스트 완료 **

### 이전 PR 내용에서 정정
- _TitleScene 내에 EventSystem을 작성해야 버튼이 작동합니다.
- 게임시작, 일시정지, 이어하기, 다시하기, 메인으로 버튼을 클릭 시 아래와 같은 메서드를 호출해주시면 되겠습니다.
    - GameManager.Instance.StartGame();
    - GameManager.Instance.PauseGame();
    - GameManager.Instance.ResumeGame();
    - GameManager.Instance.RestartGame();
    - GameManager.Instance.BackMainMenu();
- State, 타임스케일, 씬 로드 등의 기능을 수행합니다.
- Button 클릭에 사용한 코드들을 ButtonManager.cs에 추가하였습니다.

### StartGame 관련 이상 로직 해결
- GameManager.cs 에서 State 관련 로직을 모두 메서드로 대체

### UIManager.cs 에서 씬 이름 수정
- 씬 이름이 들어갈 곳에 누락되어 있던 언더바('_') 추가