### PR TITLE
Fix: 일단 Title씬의 Settings 패널에 오브젝트 할당 문제 해결(2)

### DIFF
--- a/Assets/_Script/GameManager.cs
+++ b/Assets/_Script/GameManager.cs
@@ -61,11 +61,7 @@ public class GameManager : MonoBehaviour
     }
     private void Start()
     {
-        // 임시작성
-        //UIManager.Instance.setHighScore();
 
-        // 임시작성 2
-        UIManager.Instance.settingsPanel = GameObject.Find("SettingUI");
     }
 
     public void ChangeState(GameState newState)

--- a/Assets/_Script/UIManager.cs
+++ b/Assets/_Script/UIManager.cs
@@ -23,6 +23,7 @@ public class UIManager : MonoBehaviour
         {
             Instance = this;
             DontDestroyOnLoad(gameObject);// root GameObjects 에만 사용 가능하다고 경고 뜨긴 했는데 상관은 없을듯. 경고가 신경쓰이면 오브젝트 서로 분리해도 됨.
+            SceneManager.sceneLoaded += OnSceneLoaded;
         }
         else
         {
@@ -32,7 +33,6 @@ public class UIManager : MonoBehaviour
 
     private void Start()
     {
-        SceneManager.sceneLoaded += OnSceneLoaded;
     }
 
     private void OnDestroy()
@@ -52,7 +52,7 @@ public class UIManager : MonoBehaviour
         {
             GameObject canvasObject = GameObject.Find("Canvas");
             highscore = GameObject.Find("HighScore").GetComponent<Text>();
-            settingsPanel = GameObject.Find("SettingUI");
+            settingsPanel = GameObject.Find("Canvas").transform.Find("SettingUI").gameObject;
         }
         else if (scene.name == "_MainScene")
         {
@@ -112,6 +112,8 @@ public class UIManager : MonoBehaviour
     }
     public void ToggleResultPanel(bool isActive)
     {
+        resultScore.text = GameManager.Instance.score.ToString();
+        resultHighScore.text = GameManager.Instance.highScore.ToString();
         SetPanelActive(resultPanel, isActive);
     }
     public void setCurrentScore()

--- a/Assets/_Script/UIManager.cs
+++ b/Assets/_Script/UIManager.cs
@@ -52,7 +52,6 @@ public class UIManager : MonoBehaviour
         // 로드되는 씬 이름에 따라 UI를 로드
         if (scene.name == "_TitleScene")
         {
-            GameObject canvasObject = GameObject.Find("Canvas");
             highscore = GameObject.Find("HighScore").GetComponent<Text>();
             settingsPanel = GameObject.Find("Canvas").transform.Find("SettingUI").gameObject;
         }


### PR DESCRIPTION
아래와 같이 ameObject.Find(); 와 같은 구문은, "활성화 된 상태" 인 오브젝트만 찾는다고 함.
settingsPanel = GameObject.Find("SettingUI");
이미 활성화 되어 있는 "Canvas" 오브젝트를 사용하여 그 하위 오브젝트를 선택하는 방향으로 해결
settingsPanel = GameObject.Find("Canvas").transform.Find("SettingUI").gameObject;