### PR TITLE
Fix: 메인 씬 메뉴 디스플레이 일괄 업데이트

### DIFF
--- a/Assets/_Script/GameManager.cs
+++ b/Assets/_Script/GameManager.cs
@@ -114,7 +114,7 @@ public class GameManager : MonoBehaviour
 
         // 씬 로딩 완료 후 초기화 작업 수행
         ChangeState(GameState.Playing);
-        UIManager.Instance.setCurrentScore();
+        UIManager.Instance.UpdateMainSceneMenuDisplay();
         GenerateTargetTanghulu();
     }
 
@@ -314,8 +314,9 @@ public class GameManager : MonoBehaviour
             GameOver();
         }
         GenerateTargetTanghulu();
-        Debug.Log("현재 점수: " + score);
-        Debug.Log("현재 난이도: " + currentPhase);
+
+        UIManager.Instance.UpdateMainSceneMenuDisplay();
+        Debug.Log("현재 점수: " + score + " / 현재 난이도: " + currentPhase);
     }
     public void UpdateTanghuluProgress() // 매개변수의 전달이 없을 경우, -1,-1,-1 전달
     {
@@ -356,8 +357,8 @@ public class GameManager : MonoBehaviour
                 break;
                 // 일치하는 개수가 0개인 경우 점수 증가 없음
         }
-        UIManager.Instance.setCurrentScore();
-        UIManager.Instance.setCount(tanghuluMade);
+        //UIManager.Instance.setCurrentScore();
+        //UIManager.Instance.setCount(tanghuluMade);
     }
 
     // 최고 점수 업데이트 및 저장

--- a/Assets/_Script/UIManager.cs
+++ b/Assets/_Script/UIManager.cs
@@ -11,9 +11,10 @@ public class UIManager : MonoBehaviour
     // 패널 참조를 위한 변수
     public GameObject settingsPanel;
     public GameObject pausedPanel;
+
     public Text score;
     public Text highscore;
-    public Text count;
+    public Text countTanghulu;
 
     public Text resultHighScore;
     public Text resultScore;
@@ -61,8 +62,11 @@ public class UIManager : MonoBehaviour
             GameObject canvasObject = GameObject.Find("Canvas");
             pausedPanel = canvasObject.transform.Find("PauseUI").gameObject;
             settingsPanel = GameObject.Find("SettingUI");
+
             score = canvasObject.transform.Find("Menu").transform.Find("ScoreUI").transform.Find("CurrentScore").GetComponent<Text>();
-            count = canvasObject.transform.Find("Menu").transform.Find("CountUI").transform.Find("CurrentScore").GetComponent<Text>();
+            highscore = canvasObject.transform.Find("Menu").transform.Find("ScoreUI").transform.Find("HighScore").GetComponent<Text>();
+            countTanghulu = canvasObject.transform.Find("Menu").transform.Find("CountUI").transform.Find("CurrentScore").GetComponent<Text>();
+
             resultUI = canvasObject.transform.Find("ResultUI").gameObject.GetComponent<Animator>();
             resultScore = canvasObject.transform.Find("ResultUI").transform.Find("ScoreText").GetComponent<Text>();
             resultHighScore = canvasObject.transform.Find("ResultUI").transform.Find("HighScoreText").GetComponent<Text>();
@@ -113,16 +117,23 @@ public class UIManager : MonoBehaviour
     {
         resultUI.SetTrigger("GameOver");
     }
-    public void setCurrentScore()
-    {
-        score.text = "현재 점수 " + GameManager.Instance.score.ToString();
-    }
+    //public void setCurrentScore()
+    //{
+    //    score.text = "현재 점수 " + GameManager.Instance.score.ToString();
+    //}
     public void setHighScore()
     {
         resultHighScore.text = "최고 점수 " + GameManager.Instance.highScore.ToString();
     }
-    public void setCount(int n)
+    //public void setCount(int n)
+    //{
+    //    count.text = "탕후루\n" + n + " / 10";
+    //}
+
+    public void UpdateMainSceneMenuDisplay()
     {
-        count.text = "탕후루\n" + n + " / 10";
+        highscore.text = "최고점수 " + GameManager.Instance.highScore.ToString();
+        score.text = "현재점수 " + GameManager.Instance.score.ToString();
+        countTanghulu.text = "탕후루\n" + GameManager.Instance.tanghuluMade.ToString() + " / 10";
     }
 }

--- a/Assets/_Script/UIManager.cs
+++ b/Assets/_Script/UIManager.cs
@@ -117,14 +117,14 @@ public class UIManager : MonoBehaviour
     {
         resultUI.SetTrigger("GameOver");
     }
-    public void setCurrentScore()
-    {
-        score.text = "현재 점수 " + GameManager.Instance.score.ToString();
-    }
-    public void setResultHighScore()
-    {
-        resultHighScore.text = "최고 점수 " + GameManager.Instance.highScore.ToString();
-    }
+    //public void setCurrentScore()
+    //{
+    //    score.text = "현재 점수 " + GameManager.Instance.score.ToString();
+    //}
+    //public void setResultHighScore()
+    //{
+    //    resultHighScore.text = "최고 점수 " + GameManager.Instance.highScore.ToString();
+    //}
     //public void setCount(int n)
     //{
     //    count.text = "탕후루\n" + n + " / 10";


### PR DESCRIPTION
- 탕후루 세개 꽂히고, 점수 계산 직후 시점에 메인 씬 메뉴의 데이터요소 업데이트