### PR TITLE
Fix: 변동 해상도 대응

### DIFF
--- a/Assets/Scenes/_MainScene.unity
+++ b/Assets/Scenes/_MainScene.unity
@@ -484,7 +484,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 800, y: 600}

--- a/Assets/Scenes/_TitleScene.unity
+++ b/Assets/Scenes/_TitleScene.unity
@@ -3465,7 +3465,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
   m_ReferenceResolution: {x: 800, y: 600}

--- a/Assets/_Script/GameManager.cs
+++ b/Assets/_Script/GameManager.cs
@@ -272,22 +272,30 @@ public class GameManager : MonoBehaviour
         }
         // 캔버스
         Canvas canvas = GameObject.Find("Canvas").GetComponent<Canvas>();
+
         // 'TargetTanghulu' GameObject 생성 및 캔버스의 자식으로 설정
         GameObject targetTanghuluObject = new GameObject("TargetTanghulu");
-        targetTanghuluObject.transform.SetParent(canvas.transform, false);
+        //targetTanghuluObject.transform.SetParent(canvas.transform, false);
+        Transform imageTransform = GameObject.Find("TanghuluUI").transform.Find("Image");
+        targetTanghuluObject.transform.SetParent(imageTransform, false);
 
         // "TanghuluUI" 기점으로 목표 탕후루를 표시할 위치를 지정
-        RectTransform canvasRectTransform = canvas.GetComponent<RectTransform>();
-        float posX = canvasRectTransform.sizeDelta.x / 2;
-        float posY = canvasRectTransform.sizeDelta.y / 2;
+        //RectTransform canvasRectTransform = canvas.GetComponent<RectTransform>();
+        //float posX = canvasRectTransform.sizeDelta.x / 2;
+        //float posY = canvasRectTransform.sizeDelta.y / 2;
         if (positions == null || positions.Length == 0)
         {
-            Transform tanghuluUIPosition = GameObject.Find("TanghuluUI").transform.Find("Image");
+            //Transform tanghuluUIPosition = GameObject.Find("TanghuluUI").transform.Find("Image");
             positions = new Vector3[]
+            //{
+            //    new Vector3(tanghuluUIPosition.position.x - posX, tanghuluUIPosition.position.y - posY - 50, tanghuluUIPosition.position.z),
+            //    new Vector3(tanghuluUIPosition.position.x - posX, tanghuluUIPosition.position.y - posY + 10, tanghuluUIPosition.position.z),
+            //    new Vector3(tanghuluUIPosition.position.x - posX, tanghuluUIPosition.position.y - posY + 70, tanghuluUIPosition.position.z)
+            //};
             {
-                new Vector3(tanghuluUIPosition.position.x - posX, tanghuluUIPosition.position.y - posY - 50, tanghuluUIPosition.position.z),
-                new Vector3(tanghuluUIPosition.position.x - posX, tanghuluUIPosition.position.y - posY + 10, tanghuluUIPosition.position.z),
-                new Vector3(tanghuluUIPosition.position.x - posX, tanghuluUIPosition.position.y - posY + 70, tanghuluUIPosition.position.z)
+                new Vector3(0, -50, 0),
+                new Vector3(0, 10, 0),
+                new Vector3(0, 70, 0)
             };
         }
 


### PR DESCRIPTION
- TargetTanghulu 오브젝트를 준비된 패널 이미지의 하위 오브젝트로 생성되게 하여 스폰 좌표 위치 문제 해결
- MainScene, TitleScene의 Canvas 설정을 'Scale With Screen Size'로 수정하여 변동 해상도 대응